### PR TITLE
Support non-inline transforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,20 @@ var falafel = require('falafel');
 
 var rfileModules = ['rfile', 'ruglify'];
 var deadCode = 'undefined /* removed rfile require */';
+var defaultTransformer = new InlineTransformer();
 
-module.exports = function (file) {
+module.exports = function rfileify(file) {
+
+    // When rfileify is called with a non-file, treat input as configuration
+    // options and create a new rfileify transformer instance.
+    if (file && typeof file !== 'string') {
+        var transformer = createTransformer(file);
+        return function rfileify() {
+            return module.exports.apply(transformer, arguments);
+        }
+    }
+
+    // JSON files will not contain calls to rfile.
     if (/\.json$/.test(file)) return through();
 
     var data = '';
@@ -14,15 +26,18 @@ module.exports = function (file) {
     var dirname = path.dirname(file);
     var varNames = ['__filename', '__dirname', 'path', 'join'];
     var vars = [file, dirname, path, path.join];
-    
+    var transformer = this === global ? defaultTransformer : this;
+
     return through(write, end);
-    
+
     function write (buf) { data += buf }
     function end () {
+
         var tr = this;
         var parsed = false;
+
         try {
-            var output = falafel(data, function (node) {
+            var output = falafel(transformer.preprocess(file) || data, function (node) {
                 if (requireName(node) && rfileModules.indexOf(requireName(node)) != -1 && rfileVariableName(node.parent)) {
                     rfileNames['key:' + rfileVariableName(node.parent)] = requireName(node);
                     node.update(deadCode);
@@ -36,7 +51,7 @@ module.exports = function (file) {
                     }
                     args[1] = args[1] || {};
                     args[1].basedir = args[1].basedir || dirname;
-                    node.update(JSON.stringify(rfile.apply(null, args)));
+                    node.update(transformer.transform(rfile, args, dirname));
                 }
             });
         } catch (ex) {
@@ -67,4 +82,41 @@ function variableAssignmentName(node) {
 }
 function rfileVariableName(node) {
     return variableDeclarationName(node) || variableAssignmentName(node);
+}
+function createTransformer(options) {
+    if (options.inline === false) {
+        return new ModuleTransformer();
+    } else {
+        return new InlineTransformer();
+    }
+}
+
+// Default transformer replaces rfile() calls with inline file contents.
+function InlineTransformer() {}
+InlineTransformer.prototype.preprocess = function() {}
+InlineTransformer.prototype.transform = function(rfile, args, dirname) {
+    return JSON.stringify(rfile.apply(null, args));
+}
+
+// Non-inline transformer replaces rfile() calls with require() calls, and
+// transforms those files to modules that export their contents as strings.
+function ModuleTransformer() {
+    this.entries = {};
+}
+ModuleTransformer.prototype.preprocess = function(file) {
+    var fullpath = path.resolve(file);
+    if (this.entries.hasOwnProperty(fullpath)) {
+        var entry = this.entries[fullpath];
+        var contents = entry.rfile.apply(null, entry.args);
+        return 'module.exports = ' + JSON.stringify(contents);
+    }
+}
+ModuleTransformer.prototype.transform = function(rfile, args, dirname) {
+    var fullpath = path.join(args[1].basedir, args[0]);
+    var relpath = path.relative(dirname, fullpath);
+    this.entries[fullpath] = {
+        args: args,
+        rfile: rfile
+    };
+    return 'require(' + JSON.stringify('./' + relpath) + ')';
 }


### PR DESCRIPTION
There are a couple limitations when inlining `rfile` contents:

1. Browserify (particularly [watchify](https://github.com/substack/watchify)) is not aware of changes to the included file.
2. Content strings will be duplicated if the same file is included twice.

This change allows non-inline transforms using the following syntax:

```javascript
b = browserify()
b.transform(rfileify({inline: false}));
```

For example, if this is the original:

```javascript
var rfile = require("rfile");
var foo = rfile("./foo.html");
```

The output with `{inline: false}` will look like:

```javascript
var rfile = undefined;
var foo = require("./foo.html"); // file will be picked up by browserify now
```

...and **foo.html** will look like this in the browserify output lookup:

```javascript
// foo.html
module.exports = "<h1>hello world</h1>"
```