### PR TITLE
CLI: fix for broken CLI on node >= 0.10

### DIFF
--- a/bin/rfileify
+++ b/bin/rfileify
@@ -18,4 +18,10 @@ var rs = fromFile
 
 var fpath = fromFile ? file : path.join(process.cwd(), '-');
 rs.pipe(rfileify(fpath)).pipe(process.stdout);
-rs.resume();
+if (isPre0_10()) { rs.resume(); } // OLD stream reader interface (pre-v0.10) ONLY: start reading stdin input - see http://stackoverflow.com/a/20181116/45375
+
+// Indicates if the node.js version is < 0.10.
+function isPre0_10() {
+  var aVerComponents = process.version.slice(1).split('.').map(Number);
+  return aVerComponents[0] === 0 && aVerComponents[1] < 10;
+}


### PR DESCRIPTION
Bypassing the `rs.resume()` call on node >= 0.10 to avoid an exception
- see http://stackoverflow.com/a/20181116/45375

Also note: **all Unix shell scripts - such as `bin/rfileify` - should
always be checked in with \n (Unix-style) line endings only** - using
Windows-style line endings (\r\n) breaks invocation from Unix shells.

The currently published package on npm has Windows-style line endings - this PR fixes that, too.

Finally: I'm not sure the `rs.resume()` call was ever needed - but I left it in to be safe.
